### PR TITLE
Removed: Don't write name to .nomedia

### DIFF
--- a/app/src/main/java/com/doplgangr/secrecy/Views/VaultsListFragment.java
+++ b/app/src/main/java/com/doplgangr/secrecy/Views/VaultsListFragment.java
@@ -244,9 +244,6 @@ public class VaultsListFragment extends Fragment {
             File file = new File(directory + "/.nomedia");
             file.delete();
             file.createNewFile();
-            FileOutputStream outputStream = new FileOutputStream(file);
-            outputStream.write(name.getBytes());
-            outputStream.close();
             oncreate();
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
Writing anything to the .nomedia file is not needed anymore.
