### PR TITLE
Add context null check in oncreate clauses

### DIFF
--- a/app/src/main/java/com/doplgangr/secrecy/Views/FilesListFragment.java
+++ b/app/src/main/java/com/doplgangr/secrecy/Views/FilesListFragment.java
@@ -219,6 +219,8 @@ public class FilesListFragment extends FileViewer {
     @Override
     void onCreate() {
         context = (ActionBarActivity) getActivity();
+        if (context == null)
+            return;
         context.getSupportActionBar().setTitle(vault);
         mInitializeDialog = new ProgressDialog(context);
         mInitializeDialog.setIndeterminate(true);

--- a/app/src/main/java/com/doplgangr/secrecy/Views/VaultsListFragment.java
+++ b/app/src/main/java/com/doplgangr/secrecy/Views/VaultsListFragment.java
@@ -111,7 +111,7 @@ public class VaultsListFragment extends Fragment {
             EventBus.getDefault().register(this);
         context = (ActionBarActivity) getActivity();
         if (context == null)
-            return; //Wait. What??
+            return;
         VaultHolder.getInstance().clear();
         if (mLinearView != null)
             mLinearView.removeAllViews();


### PR DESCRIPTION
Tries to fix null pointer excpetions without knowledge of where these empty contexts come from.
Attempt to fix #38 and #52 
