### PR TITLE
Improved image scaling

### DIFF
--- a/app/src/main/java/com/doplgangr/secrecy/Config.java
+++ b/app/src/main/java/com/doplgangr/secrecy/Config.java
@@ -25,6 +25,7 @@ public class Config {
     public static final int PBKDF2_CREATION_TARGET_MS = 1000;
     public static final int PBKDF2_ITERATIONS_MIN = 4096;
     public static final int PBKDF2_ITERATIONS_BENCHMARK = 20000;
+    public static final int MAX_PIXEL = 12 * 1024 * 1024; // Resulting image size: 6 > X > 12
     public static final String file_extra = "FILE";
     public static final String vault_extra = "VAULT";
     public static final String password_extra = "PASS";

--- a/app/src/main/java/com/doplgangr/secrecy/Views/FilePhotoFragment.java
+++ b/app/src/main/java/com/doplgangr/secrecy/Views/FilePhotoFragment.java
@@ -1,16 +1,17 @@
 package com.doplgangr.secrecy.Views;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.DialogInterface;
-import android.graphics.Bitmap;
-import android.graphics.drawable.BitmapDrawable;
+import android.graphics.Point;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.app.FragmentStatePagerAdapter;
-import android.support.v4.app.FragmentTransaction;
+import android.support.v4.view.ViewPager;
+import android.util.SparseArray;
+import android.view.Display;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -80,7 +81,7 @@ public class FilePhotoFragment extends FragmentActivity {
 
     public void onEventMainThread(ImageLoadDoneEvent event) {
         Util.log("Recieving imageview and bm");
-        if (event.bitmap == null && event.progressBar == null && event.imageView == null) {
+        if (event.bitmap == null) {
             Util.alert(context,
                     context.getString(R.string.Error__out_of_memory),
                     context.getString(R.string.Error__out_of_memory_message),
@@ -94,15 +95,7 @@ public class FilePhotoFragment extends FragmentActivity {
             return;
         }
         try {
-            int vHeight = event.imageView.getHeight();
-            int vWidth = event.imageView.getWidth();
-            int bHeight = event.bitmap.getHeight();
-            int bWidth = event.bitmap.getWidth();
-            float ratio = vHeight / bHeight < vWidth / bWidth ? (float) vHeight / bHeight : (float) vWidth / bWidth;
-            Util.log(vHeight, vWidth, bHeight, bWidth);
-            Util.log(ratio);
-            event.imageView.setImageBitmap(Bitmap.createScaledBitmap(event.bitmap, (int) (ratio * bWidth)
-                    , (int) (ratio * bHeight), false));
+            event.imageView.setImageBitmap(event.bitmap);
         } catch (OutOfMemoryError e) {
             Util.alert(context,
                     context.getString(R.string.Error__out_of_memory),
@@ -146,10 +139,8 @@ public class FilePhotoFragment extends FragmentActivity {
             return PhotoFragment.newInstance(position);
         }
 
-
         public static class PhotoFragment extends Fragment {
             int mNum;
-            PhotoView photoView;
             private ImageLoadJob imageLoadJob = null;
 
             static PhotoFragment newInstance(int num) {
@@ -161,7 +152,6 @@ public class FilePhotoFragment extends FragmentActivity {
 
                 return f;
             }
-
 
             @Override
             public void onCreate(Bundle savedInstanceState) {
@@ -180,7 +170,6 @@ public class FilePhotoFragment extends FragmentActivity {
                 final RelativeLayout relativeLayout = new RelativeLayout(container.getContext());
                 final EncryptedFile encryptedFile = encryptedFiles.get(mNum);
                 final PhotoView photoView = new PhotoView(container.getContext());
-                this.photoView = photoView;
                 relativeLayout.addView(photoView, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
                 try {
                     photoView.setImageBitmap(encryptedFile.getEncryptedThumbnail().getThumb(150));
@@ -200,13 +189,17 @@ public class FilePhotoFragment extends FragmentActivity {
             @Override
             public void onPause(){
                 super.onPause();
-                imageLoadJob.setObsolet(true);
+                if (imageLoadJob != null) {
+                    imageLoadJob.setObsolet(true);
+                }
             }
 
             @Override
             public void onDestroy(){
                 super.onDestroy();
-                imageLoadJob.setObsolet(true);
+                if (imageLoadJob != null) {
+                    imageLoadJob.setObsolet(true);
+                }
             }
 
         }


### PR DESCRIPTION
Images are now scaled directly at creation. This allows to load even
large images without out of memory problems.

It further allows to set the max scaling factor according to device
limitations.

Since the inSampleSize scaler can only scale to factors of 2, the
resulting image size is somewhere between MAX_PIXEL/2 and MAX_PIXEL.

This could fix the out of memory errors forever. We might add a option where the user can set the max image size to small, medium or large (if the current value doesn't fit all devices).

I could load 20Mpix images with this change which otherwise directly caused an out of memory error.

I would like to have this change in the current alpha release!
