### PR TITLE
Reduced max image sizes

### DIFF
--- a/app/src/main/java/com/doplgangr/secrecy/Config.java
+++ b/app/src/main/java/com/doplgangr/secrecy/Config.java
@@ -26,8 +26,8 @@ public class Config {
     public static final int PBKDF2_ITERATIONS_MIN = 4096;
     public static final int PBKDF2_ITERATIONS_BENCHMARK = 20000;
     public static final int IMAGE_SIZE_SMALL = 4 * 1000 * 1000; // Resulting image size: 2 > X > 4
-    public static final int IMAGE_SIZE_MEDIUM = 8 * 1000 * 1000; // Resulting image size: 4 > X > 8
-    public static final int IMAGE_SIZE_LARGE = 16 * 1000 * 1000; // Resulting image size: 8 > X > 16
+    public static final int IMAGE_SIZE_MEDIUM = 6 * 1000 * 1000; // Resulting image size: 3 > X > 6
+    public static final int IMAGE_SIZE_LARGE = 10 * 1000 * 1000; // Resulting image size: 5 > X > 10
     public static int selectedImageSize = 0;
     public static final String file_extra = "FILE";
     public static final String vault_extra = "VAULT";


### PR DESCRIPTION
Estimated heap sizes of loaded bitmaps: (megapixel \* 4)

Small: ~ 7,5 MB - 15 MB
Medium: ~ 11,5 MB - 23 MB
Large: ~ 19 MB - 38 MB

This values should be more realistic.
