### PR TITLE
Ignore lint errors in aFileChooser

### DIFF
--- a/aFileChooser/build.gradle
+++ b/aFileChooser/build.gradle
@@ -8,6 +8,10 @@ android {
         minSdkVersion 10
         targetSdkVersion 19
     }
+
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
After merging the open PRs from @Doplgangr, building in Android Studio is almost fixed. Only aFileChooser aborts due to lint errors. 

Fixes #82 