### PR TITLE
Fixed call broadcast not aborted

### DIFF
--- a/app/src/main/java/com/doplgangr/secrecy/OutgoingCallReceiver.java
+++ b/app/src/main/java/com/doplgangr/secrecy/OutgoingCallReceiver.java
@@ -55,10 +55,10 @@ public class OutgoingCallReceiver extends BroadcastReceiver {
     }
 
     void launchActivity(Context context, Intent launcher) {
+        setResultData(null);
         //Try hiding app everytime, prevent reappearance of app icon.
         StealthMode.hideApp(context);
         context.startActivity(launcher);
         // Cancel the call.
-        abortBroadcast();
     }
 }


### PR DESCRIPTION
The call was not correctly aborted in Android 5. This fix seems to work. Would be nice if someone else could test the existence of the bug and if this solution works. 