### PR TITLE
Partly fix decryption while rotating

### DIFF
--- a/app/src/main/java/com/doplgangr/secrecy/views/FilesActivity.java
+++ b/app/src/main/java/com/doplgangr/secrecy/views/FilesActivity.java
@@ -102,7 +102,6 @@ public class FilesActivity extends ActionBarActivity
 
     @Override
     public void onDestroy() {
-        Storage.deleteTemp(); //Cleanup every time
         EventBus.getDefault().post(new shouldRefresh());
         super.onDestroy();
     }

--- a/app/src/main/java/com/doplgangr/secrecy/views/FilesListFragment.java
+++ b/app/src/main/java/com/doplgangr/secrecy/views/FilesListFragment.java
@@ -110,6 +110,7 @@ public class FilesListFragment extends FileViewer {
         recyclerView = (RecyclerView) view.findViewById(R.id.file_list_recycler_view);
         mTag = (TextView) view.findViewById(R.id.tag);
 
+        linearLayout = new LinearLayoutManager(context);
         recyclerView.setHasFixedSize(true);
         recyclerView.setLayoutManager(linearLayout);
         recyclerView.setAdapter(mAdapter);
@@ -141,19 +142,20 @@ public class FilesListFragment extends FileViewer {
         }
         context.getSupportActionBar().setTitle(vault);
 
-        linearLayout = new LinearLayoutManager(context);
         gridLayout = new GridLayoutManager(context, 3);
         listAdapter = new FilesListAdapter(context, false);
         galleryAdapter = new FilesListAdapter(context, true);
         mAdapter = listAdapter;
 
-        mInitializeDialog = new ProgressDialog(context);
-        mInitializeDialog.setIndeterminate(true);
-        mInitializeDialog.setMessage(context.getString(R.string.Vault__initializing));
-        mInitializeDialog.setCancelable(false);
-        mInitializeDialog.show();
+        if (secret == null) {
+            mInitializeDialog = new ProgressDialog(context);
+            mInitializeDialog.setIndeterminate(true);
+            mInitializeDialog.setMessage(context.getString(R.string.Vault__initializing));
+            mInitializeDialog.setCancelable(false);
+            mInitializeDialog.show();
 
-        CustomApp.jobManager.addJobInBackground(new InitializeVaultJob(vault, password));
+            CustomApp.jobManager.addJobInBackground(new InitializeVaultJob(vault, password));
+        }
     }
 
     @Override
@@ -227,8 +229,9 @@ public class FilesListFragment extends FileViewer {
         getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                if (frame == null)
+                if (frame == null) {
                     return;
+                }
                 FilesListAdapter.ViewHolder holder = (FilesListAdapter.ViewHolder) frame.getTag();
                 ViewAnimator viewAnimator = holder.animator;
                 viewAnimator.setInAnimation(context, R.anim.slide_down);


### PR DESCRIPTION
Based on #102. Only added commit is: c6cf6da

Files are now correctly decrypted, but the view is not reset after
decryption. Probably because a new view is created while rotating.