### PR TITLE
Don't stack fragments in MainActivity

### DIFF
--- a/app/src/main/java/com/doplgangr/secrecy/views/MainActivity.java
+++ b/app/src/main/java/com/doplgangr/secrecy/views/MainActivity.java
@@ -239,21 +239,34 @@ public class MainActivity extends ActionBarActivity implements
     }
 
     void addFragment(final Fragment fragment, int transition1, int transition2) {
-        if (mFragmentNameList.contains(fragment.getClass()))
+        if (mFragmentNameList.contains(fragment.getClass())) {
             mNavigation.setSelectedItem(mFragmentNameList.indexOf(fragment.getClass()));
+        }
         String tag = fragment.getClass().getName();
         FragmentManager manager = getSupportFragmentManager();
-        if (manager.getBackStackEntryCount() > 1) {
-            FragmentManager.BackStackEntry first = manager.getBackStackEntryAt(1);
+        if (manager.getBackStackEntryCount() >= 1) {
+
+            String activeFragmentTag = getSupportFragmentManager()
+                    .getBackStackEntryAt(getSupportFragmentManager()
+                            .getBackStackEntryCount() - 1).getName();
+            Fragment activeFragment =  getSupportFragmentManager()
+                    .findFragmentByTag(activeFragmentTag);
+            // Don't switch fragment if already active
+            if (activeFragment.getClass().equals(fragment.getClass())){
+                return;
+            }
+            //clear all except lowest
+            FragmentManager.BackStackEntry first = manager.getBackStackEntryAt(0);
             manager.popBackStackImmediate(first.getId(), FragmentManager.POP_BACK_STACK_INCLUSIVE);
-        }           //clear all except lowest
+        }
         FragmentTransaction transaction = fragmentManager.beginTransaction()
                 .setCustomAnimations(transition1, transition2)
                 .replace(R.id.content_frame, fragment, tag);
-        if (fragment.getClass() != VaultsListFragment.class)
+        if (fragment.getClass() != VaultsListFragment.class) {
             transaction = transaction
                     .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
                     .addToBackStack(tag);
+        }
         transaction.commit();
     }
 


### PR DESCRIPTION
If a fragment like the settings was selected more than once, the fragments were stacked and the user had to press home twice to get back to the vault list. This is fixed by this PR. Also if the currently active fragment is selected, reloading the fragment is skipped.

I also noticed a little bug. If the user is in the settings fragment, presses back, the settings fragment stays the highlighted item. We probably need to override the back pressed action and reset the highlighted item. But this can be done in another PR. 