### PR TITLE
Revert "Fixed: Exit to vault list on screen lock in photo view"

### DIFF
--- a/app/src/main/java/com/doplgangr/secrecy/fragments/FilePhotoFragment.java
+++ b/app/src/main/java/com/doplgangr/secrecy/fragments/FilePhotoFragment.java
@@ -212,7 +212,6 @@ public class FilePhotoFragment extends FragmentActivity {
                 if (imageLoadJob != null) {
                     imageLoadJob.setObsolet(true);
                 }
-                getActivity().finish();
             }
 
             @Override


### PR DESCRIPTION
Reverts SecrecySupportTeam/secrecy#119

This fix doesn't work as intended. Swiping to the images is broken.