### PR TITLE
Fixed: Exit to vault list on screen lock in photo view

### DIFF
--- a/app/src/main/java/com/doplgangr/secrecy/fragments/FilePhotoFragment.java
+++ b/app/src/main/java/com/doplgangr/secrecy/fragments/FilePhotoFragment.java
@@ -73,6 +73,12 @@ public class FilePhotoFragment extends FragmentActivity {
     }
 
     @Override
+    protected void onPause() {
+        super.onPause();
+        finish();
+    }
+
+    @Override
     public void onDestroy(){
         super.onDestroy();
         EventBus.getDefault().unregister(this);
@@ -212,7 +218,6 @@ public class FilePhotoFragment extends FragmentActivity {
                 if (imageLoadJob != null) {
                     imageLoadJob.setObsolet(true);
                 }
-                getActivity().finish();
             }
 
             @Override


### PR DESCRIPTION
Maybe this fix works better :)
It was a little confusing that the FilePhotoFragment.java contains an FragmentActivity and a FragmentStatePagerAdapter.