### PR TITLE
Exit to vault list

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.doplgangr.secrecy">
+    package="com.doplgangr.secrecy" >
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
@@ -16,13 +16,12 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/App__name"
-        android:theme="@style/CustomMaterialTheme">
-
+        android:theme="@style/CustomMaterialTheme" >
         <provider
             android:name=".filesystem.OurFileProvider"
             android:authorities="com.doplgangr.secrecy.filesystem.DecryptFileProvider"
             android:exported="false"
-            android:grantUriPermissions="true">
+            android:grantUriPermissions="true" >
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_path" />
@@ -35,7 +34,7 @@
             android:label="@string/Dialog_header__pick_file" />
         <activity
             android:name=".activities.FileImportActivity"
-            android:label="@string/Dialog_header__import_files">
+            android:label="@string/Dialog_header__import_files" >
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
 
@@ -55,17 +54,18 @@
             android:name=".activities.ChooseFolder"
             android:label="@string/Page_header__choose_folder" />
 
-        <receiver android:name=".OutgoingCallReceiver">
-            <intent-filter android:priority="9999">
+        <receiver android:name=".OutgoingCallReceiver" >
+            <intent-filter android:priority="9999" >
                 <action android:name="android.intent.action.NEW_OUTGOING_CALL" />
             </intent-filter>
         </receiver>
+
         <activity
             android:name=".views.LauncherActivity"
             android:clearTaskOnLaunch="true"
             android:excludeFromRecents="true"
             android:finishOnTaskLaunch="true"
-            android:label="@string/App__name">
+            android:label="@string/App__name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -77,14 +77,14 @@
             android:clearTaskOnLaunch="true"
             android:excludeFromRecents="true"
             android:finishOnTaskLaunch="true"
-            android:label="@string/App__name"></activity>
+            android:label="@string/App__name" />
         <activity
             android:name=".fragments.FilePhotoFragment"
             android:clearTaskOnLaunch="true"
             android:excludeFromRecents="true"
             android:finishOnTaskLaunch="true"
             android:label=""
-            android:parentActivityName=".activities.FilesActivity">
+            android:parentActivityName=".activities.FilesActivity" >
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activities.FilesActivity" />
@@ -92,8 +92,14 @@
         <activity
             android:name=".activities.FilesActivity"
             android:label=""
-            android:parentActivityName=".activities.MainActivity">
+            android:parentActivityName=".activities.MainActivity" >
         </activity>
+
+        <service
+            android:name=".services.ScreenStateService"
+            android:enabled="true"
+            android:exported="false" >
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/doplgangr/secrecy/events/ScreenOffEvent.java
+++ b/app/src/main/java/com/doplgangr/secrecy/events/ScreenOffEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package com.doplgangr.secrecy.events;
+
+
+public class ScreenOffEvent {
+
+
+    public ScreenOffEvent() {
+
+    }
+}

--- a/app/src/main/java/com/doplgangr/secrecy/fragments/FilePhotoFragment.java
+++ b/app/src/main/java/com/doplgangr/secrecy/fragments/FilePhotoFragment.java
@@ -19,14 +19,15 @@ import android.widget.RelativeLayout;
 
 import com.doplgangr.secrecy.Config;
 import com.doplgangr.secrecy.CustomApp;
+import com.doplgangr.secrecy.R;
 import com.doplgangr.secrecy.events.ImageLoadDoneEvent;
 import com.doplgangr.secrecy.exceptions.SecrecyFileException;
+import com.doplgangr.secrecy.filesystem.encryption.Vault;
 import com.doplgangr.secrecy.filesystem.encryption.VaultHolder;
 import com.doplgangr.secrecy.filesystem.files.EncryptedFile;
-import com.doplgangr.secrecy.filesystem.encryption.Vault;
 import com.doplgangr.secrecy.jobs.ImageLoadJob;
-import com.doplgangr.secrecy.R;
 import com.doplgangr.secrecy.utils.Util;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -36,8 +37,9 @@ import uk.co.senab.photoview.PhotoView;
 
 public class FilePhotoFragment extends FragmentActivity {
 
-    private static Activity context;
+    private static Activity mContext;
     private ViewPager mViewPager;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -46,48 +48,46 @@ public class FilePhotoFragment extends FragmentActivity {
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_view_pager);
+        mContext = this;
 
-        if (!EventBus.getDefault().isRegistered(this))
-            EventBus.getDefault().register(this);
         final SamplePagerAdapter adapter = new SamplePagerAdapter(getSupportFragmentManager());
-
-        Bundle extras = getIntent().getExtras();
 
         mViewPager = (ViewPager) findViewById(R.id.view_pager);
         mViewPager.setAdapter(adapter);
         Vault secret = VaultHolder.getInstance().retrieveVault();
-        Vault.onFileFoundListener mListener = new Vault.onFileFoundListener() {
+        secret.iterateAllFiles(new Vault.onFileFoundListener() {
             @Override
             public void dothis(EncryptedFile file) {
                 adapter.add(file);
             }
-        };
-        secret.iterateAllFiles(mListener);
-        context = this;
+        });
+
         adapter.sort();
 
-        int itemNo = extras.getInt(Config.gallery_item_extra);
+        int itemNo = getIntent().getExtras().getInt(Config.gallery_item_extra);
         if (itemNo < (mViewPager.getAdapter().getCount())) { //check if requested item is in bound
             mViewPager.setCurrentItem(itemNo);
         }
+
+        EventBus.getDefault().register(this);
     }
 
     @Override
-    public void onDestroy(){
-        super.onDestroy();
+    protected void onDestroy() {
         EventBus.getDefault().unregister(this);
+        super.onDestroy();
     }
 
     public void onEventMainThread(ImageLoadDoneEvent event) {
         Util.log("Recieving imageview and bm");
         if (event.bitmap == null) {
-            Util.alert(context,
-                    context.getString(R.string.Error__out_of_memory),
-                    context.getString(R.string.Error__out_of_memory_message),
+            Util.alert(mContext,
+                    mContext.getString(R.string.Error__out_of_memory),
+                    mContext.getString(R.string.Error__out_of_memory_message),
                     new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {
-                            context.finish();
+                            mContext.finish();
                         }
                     },
                     null);
@@ -96,13 +96,13 @@ public class FilePhotoFragment extends FragmentActivity {
         try {
             event.imageView.setImageBitmap(event.bitmap);
         } catch (OutOfMemoryError e) {
-            Util.alert(context,
-                    context.getString(R.string.Error__out_of_memory),
-                    context.getString(R.string.Error__out_of_memory_message),
+            Util.alert(mContext,
+                    mContext.getString(R.string.Error__out_of_memory),
+                    mContext.getString(R.string.Error__out_of_memory_message),
                     new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {
-                            context.finish();
+                            mContext.finish();
                         }
                     },
                     null);
@@ -128,14 +128,14 @@ public class FilePhotoFragment extends FragmentActivity {
             notifyDataSetChanged();
         }
 
-        public void sort(){
+        public void sort() {
             Comparator<EncryptedFile> comparator;
 
-            switch (PreferenceManager.getDefaultSharedPreferences(context).getString(
+            switch (PreferenceManager.getDefaultSharedPreferences(mContext).getString(
                     Config.VAULT_SORT, Config.VAULT_SORT_ALPHABETIC)) {
 
                 case Config.VAULT_SORT_ALPHABETIC:
-                   comparator = Config.COMPARATOR_ENCRYPTEDFILE_ALPHABETIC;
+                    comparator = Config.COMPARATOR_ENCRYPTEDFILE_ALPHABETIC;
                     break;
                 case Config.VAULT_SORT_FILETYPE:
                     comparator = Config.COMPARATOR_ENCRYPTEDFILE_FILETYPE;
@@ -207,7 +207,7 @@ public class FilePhotoFragment extends FragmentActivity {
             }
 
             @Override
-            public void onPause(){
+            public void onPause() {
                 super.onPause();
                 if (imageLoadJob != null) {
                     imageLoadJob.setObsolet(true);
@@ -215,7 +215,7 @@ public class FilePhotoFragment extends FragmentActivity {
             }
 
             @Override
-            public void onDestroy(){
+            public void onDestroy() {
                 super.onDestroy();
                 if (imageLoadJob != null) {
                     imageLoadJob.setObsolet(true);

--- a/app/src/main/java/com/doplgangr/secrecy/services/ScreenStateService.java
+++ b/app/src/main/java/com/doplgangr/secrecy/services/ScreenStateService.java
@@ -1,0 +1,55 @@
+package com.doplgangr.secrecy.services;
+
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.IBinder;
+
+import com.doplgangr.secrecy.events.ScreenOffEvent;
+
+import de.greenrobot.event.EventBus;
+
+/**
+ * This service registers a {@code android.content.BroadcastReceiver} to catch {@code android.intent.action.SCREEN_OFF}.
+ */
+public class ScreenStateService extends Service {
+    private static final String SCREEN_OFF = "android.intent.action.SCREEN_OFF";
+    private static final String SCREEN_ON = "android.intent.action.SCREEN_ON";
+    private ScreenStateReceiver mScreenStateReceiver;
+
+    public ScreenStateService() {
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        mScreenStateReceiver = new ScreenStateReceiver();
+        final IntentFilter screenStateFilter = new IntentFilter(Intent.ACTION_SCREEN_OFF);
+        registerReceiver(mScreenStateReceiver, screenStateFilter);
+    }
+
+    @Override
+    public void onDestroy() {
+        unregisterReceiver(mScreenStateReceiver);
+        super.onDestroy();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        // TODO: Return the communication channel to the service.
+        return null;
+    }
+
+    class ScreenStateReceiver extends BroadcastReceiver {
+
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (intent.getAction().equalsIgnoreCase(SCREEN_OFF)) {
+                EventBus.getDefault().post(new ScreenOffEvent());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Make the app receive SCREEN_OFF events and close the photo view when screen is locked. The broadcast receiver is added in a service so it can be used when the activities are not in foreground. The service will trigger a custom "ScreenOff" event through the EventBus and any subscribers can take the required action.