### PR TITLE
File deletion improvement

### DIFF
--- a/app/src/main/java/com/doplgangr/secrecy/filesystem/Storage.java
+++ b/app/src/main/java/com/doplgangr/secrecy/filesystem/Storage.java
@@ -19,6 +19,7 @@
 
 package com.doplgangr.secrecy.filesystem;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -60,16 +61,11 @@ public class Storage {
     }
 
     public static void purgeFile(File file) {
-        if (file == null){
-            return;
-        }
-        purgeFile(file, null);
+        CustomApp.jobManager.addJobInBackground(new DeleteFileJob(file)); // deletion in background
     }
 
-    public static void purgeFile(File file, Uri uri) {        //Starts a job to do the real
-        DeleteFileJob job = new DeleteFileJob(file);
-        job.addURI(uri);
-        CustomApp.jobManager.addJobInBackground(job); // deletion in background
+    public static void purgeFile(Uri uri) {        //Starts a job to do the real
+        CustomApp.jobManager.addJobInBackground(new DeleteFileJob(uri)); // deletion in background
     }
 
     public static void shredFile(OutputStream fileOS, long size, File file) {
@@ -134,7 +130,7 @@ public class Storage {
                 DeleteRecursive(externalCacheDir);                      //Just to be sure
     }
 
-       public static Bitmap getThumbnailfromStream(SecrecyCipherInputStream streamThumb, int size) {
+    public static Bitmap getThumbnailfromStream(SecrecyCipherInputStream streamThumb, int size) {
         if (streamThumb != null) {
             try {
                 byte[] bytes = IOUtils.toByteArray(streamThumb);

--- a/app/src/main/java/com/doplgangr/secrecy/jobs/AddFileJob.java
+++ b/app/src/main/java/com/doplgangr/secrecy/jobs/AddFileJob.java
@@ -3,6 +3,7 @@ package com.doplgangr.secrecy.jobs;
 import android.content.Context;
 import android.net.Uri;
 
+import com.doplgangr.secrecy.CustomApp;
 import com.doplgangr.secrecy.events.AddingFileDoneEvent;
 import com.doplgangr.secrecy.events.AddingFileEvent;
 import com.doplgangr.secrecy.events.NewFileEvent;
@@ -47,8 +48,7 @@ public class AddFileJob extends Job {
         EventBus.getDefault().post(new NewFileEvent(returnedEncryptedFile));
 
         EventBus.getDefault().post(new AddingFileDoneEvent(vault));
-        File actualFile = new File(getPath(context, uri));
-        Storage.purgeFile(actualFile, uri); //Try to delete original file.
+        CustomApp.jobManager.addJob(new DeleteFileJob(uri));   //Don't create yet another bg thread.
     }
 
     @Override

--- a/app/src/main/java/com/doplgangr/secrecy/jobs/DeleteFileJob.java
+++ b/app/src/main/java/com/doplgangr/secrecy/jobs/DeleteFileJob.java
@@ -65,9 +65,6 @@ public class DeleteFileJob extends Job {
 
             //2. File deleted once. Rescan and remove it from gallery
             new SingleMediaScanner(context, file);
-
-            //3. Desperately delete again, just to be sure if shred file job failed.
-            FileUtils.forceDelete(file);
         }
         if (uri != null){
             //4. Delete under content resolver
@@ -75,6 +72,9 @@ public class DeleteFileJob extends Job {
                 DocumentsContract.deleteDocument(context.getContentResolver(), uri); //For kitkat users
             context.getContentResolver().delete(uri, null, null);
         }
+        //3. Desperately delete again, just to be sure if shred file job failed.
+        if (file != null)
+            FileUtils.deleteQuietly(file);
     }
 
     @Override

--- a/app/src/main/java/com/doplgangr/secrecy/jobs/DeleteFileJob.java
+++ b/app/src/main/java/com/doplgangr/secrecy/jobs/DeleteFileJob.java
@@ -87,7 +87,7 @@ public class DeleteFileJob extends Job {
     @Override
     protected boolean shouldReRunOnThrowable(Throwable throwable) {
         //ignore everything and rerun
-        throwable.printStackTrace();
+        Util.log(throwable.getMessage());
         return true;
     }
 

--- a/app/src/main/java/com/doplgangr/secrecy/jobs/ShredFileJob.java
+++ b/app/src/main/java/com/doplgangr/secrecy/jobs/ShredFileJob.java
@@ -29,8 +29,8 @@ public class ShredFileJob extends Job {
 
     @Override
     public void onRun() throws Throwable {
-        Util.log("Shreddd");
-        // Double check
+        Util.log("Shredding, filesize",size);
+
         OutputStream os = new BufferedOutputStream(fileOs);
         try {
             for (int i = 0; i < size; i++)
@@ -38,31 +38,24 @@ public class ShredFileJob extends Job {
         } finally {
             os.close();
         }
-        Boolean ignored = file.delete();
         FileUtils.forceDelete(file);
     }
 
     @Override
     protected void onCancel() {
-        //Rarhhh go die.
-        Boolean ignoredBoolean = file.delete();
-        try {
-            FileUtils.forceDelete(file);
-        } catch (Exception ignored) { // If it never gets to the end...
-            ignored.printStackTrace();
-        }
+        // Final try, in case it is problem associated with output stream.
+        FileUtils.deleteQuietly(file);
     }
 
     @Override
     protected boolean shouldReRunOnThrowable(Throwable throwable) {
-        Util.log("Shredding retry");
         throwable.printStackTrace();
         return true;
     }
 
     @Override
     protected int getRetryLimit() {
-        return 10;  //This is quite reasonable. Isn't it?
+        return 10;
     }
 
 }

--- a/app/src/main/java/com/doplgangr/secrecy/jobs/ShredFileJob.java
+++ b/app/src/main/java/com/doplgangr/secrecy/jobs/ShredFileJob.java
@@ -49,7 +49,7 @@ public class ShredFileJob extends Job {
 
     @Override
     protected boolean shouldReRunOnThrowable(Throwable throwable) {
-        throwable.printStackTrace();
+        Util.log(throwable.getMessage());
         return true;
     }
 

--- a/app/src/main/java/com/doplgangr/secrecy/jobs/ShredFileJob.java
+++ b/app/src/main/java/com/doplgangr/secrecy/jobs/ShredFileJob.java
@@ -38,7 +38,7 @@ public class ShredFileJob extends Job {
         } finally {
             os.close();
         }
-        FileUtils.forceDelete(file);
+        FileUtils.deleteQuietly(file);
     }
 
     @Override


### PR DESCRIPTION
The original classes are quite messy. After some thoughts and experimentation here are some improvements
- Silencing deleting functions so that they do not repeatedly result in a rerun, and causing unnecessary us of computational power.
- Reorder functions so that there would always be a final deletion function. (In some samsung devices, the shredding function creates a file with 0 filesize.)
- reducing size of log so that the >10 reruns do not create a massive congestion in the logcats.
- More sensible comments.
